### PR TITLE
FIX deprecation notice about double quote

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,33 +13,33 @@ parameters:
 services:
     # makes the calls to API
     qowisio.cloud.api.caller:
-        class: %qowisio.cloud.api.caller.class%
+        class: "%qowisio.cloud.api.caller.class%"
         arguments:
-            - %qowisio.cloud.api.auth.endpoint%
-            - %qowisio.cloud.api.auth.email%
-            - %qowisio.cloud.api.auth.password%
-            - %qowisio.cloud.api.data.endpoint%
+            - "%qowisio.cloud.api.auth.endpoint%"
+            - "%qowisio.cloud.api.auth.email%"
+            - "%qowisio.cloud.api.auth.password%"
+            - "%qowisio.cloud.api.data.endpoint%"
 
     # Get infos about authentication
     qowisio.cloud.api.authentication:
-        class: %qowisio.cloud.api.authentication.class%
+        class: "%qowisio.cloud.api.authentication.class%"
         arguments:
             - "@qowisio.cloud.api.caller"
 
     # Get infos about devices and their sensors
     qowisio.cloud.api.devices.and.sensors:
-        class: %qowisio.cloud.api.devices.and.sensors.class%
+        class: "%qowisio.cloud.api.devices.and.sensors.class%"
         arguments:
             - "@qowisio.cloud.api.caller"
 
     # Get infos about sensor measures
     qowisio.cloud.api.measures:
-        class: %qowisio.cloud.api.measures.class%
+        class: "%qowisio.cloud.api.measures.class%"
         arguments:
             - "@qowisio.cloud.api.caller"
 
     # Get info about the specific tracker device
     qowisio.tracker:
-        class: %qowisio.tracker.class%
+        class: "%qowisio.tracker.class%"
         arguments:
             - "@qowisio.cloud.api.measures"


### PR DESCRIPTION
FIX deprecation notice about double quote arround parameters in service
definition.

Ex :
qowisio.cloud.api.devices.and.sensors:
    class: "%qowisio.cloud.api.devices.and.sensors.class%"